### PR TITLE
fix build error and expose additional options for tailwind to use scss

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,12 +28,21 @@ const validBuildTargets = Object.keys(buildDestinations);
 module.exports = {
 	name: 'ember-cli-tailwind',
 
+	tailwindOptions: null,
+
 	isDevelopingAddon() {
 		return true;
 	},
 
 	included(includer) {
 		this._super.included.apply(this, arguments);
+
+		if (includer.options.hasOwnProperty(this.name)) {
+			this.tailwindOptions = Object.assign({}, this._defaultOptions(), includer.options[this.name]);
+		}
+		else {
+			this.tailwindOptions = this._defaultOptions();
+		}
 
 		// If this is set, show a warning
 		let explicitBuildTarget = includer.options &&
@@ -91,11 +100,24 @@ module.exports = {
 
 		if (!this._shouldIncludeStyleguide()) {
 			appTree = new Funnel(appTree, {
-				exclude: ['**/instance-initializers/ember-cli-tailwind.js'],
+				exclude: [
+					'**/instance-initializers/ember-cli-tailwind.js',
+				],
 			});
 		}
 
 		return debugTree(appTree, 'tree-for-app');
+	},
+
+	_defaultOptions() {
+		return {
+			shouldBuildTailwind: true,
+			outputFile: 'tailwind.css',
+			modulesFile: 'modules.css',
+			easyImport: {
+				extensions: ['.css'],
+			},
+		};
 	},
 
 	_shouldIncludeStyleguide() {
@@ -171,6 +193,6 @@ module.exports = {
 	},
 
 	_config() {
-		return this.parent.config(process.env.EMBER_ENV)[this.name] || {};
+		return this.tailwindOptions;
 	}
 };

--- a/lib/build-tailwind.js
+++ b/lib/build-tailwind.js
@@ -17,12 +17,15 @@ module.exports = function(addon) {
   let tailwindAddon;
   if (addon.pkg.name === 'ember-cli-tailwind') {
     tailwindAddon = addon;
-  } else {
+  }
+  else {
     tailwindAddon = addon.findOwnAddonByName('ember-cli-tailwind');
   }
-  let inputPath = tailwindAddon.tailwindInputPath;
 
-  let tailwindConfigTree = new Rollup(inputPath, {
+  const inputPath = tailwindAddon.tailwindInputPath;
+  const config = tailwindAddon._config();
+
+  const tailwindConfigTree = new Rollup(inputPath, {
     rollup: {
       input: 'config/tailwind.js',
       output: {
@@ -37,8 +40,12 @@ module.exports = function(addon) {
   });
 
   return new BuildTailwindPlugin([ inputPath, tailwindConfigTree ], {
-    srcFile: 'modules.css',
-    cacheInclude: [/.*\.(js|css)$/]
+    srcFile: config.modulesFile || 'modules.css',
+    cacheInclude: [/.*\.(js|css)$/],
+
+    // pass additional options to buildTailwind
+    easyImportOptions: config.easyImport || {},
+    outputFile: config.outputFile || 'tailwind.css',
   });
 }
 
@@ -48,15 +55,19 @@ class BuildTailwindPlugin extends BroccoliPlugin {
     super(inputTrees, options);
     this.srcFile = options.srcFile;
     this.didBuild = options.didBuild;
+
+    // added options in our fork
+    this._easyImportOptions = options.easyImportOptions;
+    this._outputFile = options.outputFile;
   }
 
   build() {
     let modulesFile = path.join(this.inputPaths[0], this.srcFile);
     let configFile = path.join(this.inputPaths[1], 'tailwind-config.js');
-    let outputFile = path.join(this.outputPath, 'tailwind.css');
+    let outputFile = path.join(this.outputPath, this._outputFile);
 
     return postcss([
-      easyImport,
+      easyImport(this._easyImportOptions),
       tailwind(configFile)
     ])
     .process(fs.readFileSync(modulesFile, 'utf-8'), { from: modulesFile })
@@ -65,5 +76,4 @@ class BuildTailwindPlugin extends BroccoliPlugin {
       fs.writeFileSync(outputFile, result.css)
     });
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-tailwind",
-  "version": "0.6.3",
+  "version": "0.6.3-ab-v1.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
# 0.6.3-ab-v1.0
##### 2020-01-28

- exposed additional options to configure tailwind for newer versions of ember-cli
- resolves `broccoli-persistent-filter:CleanCSSFilter` error
  - https://github.com/embermap/ember-cli-tailwind/issues/37
- allows configuring the output file, modules file, and easyImport extensions from the consuming app/addon